### PR TITLE
addUserProperties prop for jmeter

### DIFF
--- a/src/org/programmerplanet/ant/taskdefs/jmeter/JMeterTask.java
+++ b/src/org/programmerplanet/ant/taskdefs/jmeter/JMeterTask.java
@@ -48,6 +48,14 @@ public class JMeterTask extends Task {
 	 */
 	private File jmeterProperties;
 
+	
+	/**
+	 * Additional user property file to use
+	 */
+	private File additionalUserProperties;
+	
+	
+
 	/**
 	 * The test plan to execute.
 	 */
@@ -269,6 +277,12 @@ public class JMeterTask extends Task {
 			cmd.createArgument().setValue("-j");
 			cmd.createArgument().setValue(jmeterLogFile.getAbsolutePath());
 		}
+		
+		// add user property
+		if (additionalUserProperties != null) {
+					cmd.createArgument().setValue("-q");
+					cmd.createArgument().setValue(additionalUserProperties.getAbsolutePath());
+				}
 		// the test plan file
 		cmd.createArgument().setValue("-t");
 		cmd.createArgument().setValue(testPlanFile.getAbsolutePath());
@@ -441,4 +455,12 @@ public class JMeterTask extends Task {
 		getProject().setProperty(failureProperty, "true");
 	}
 
+	public File getAdditionalUserProperties() {
+		return additionalUserProperties;
+	}
+
+	public void setAdditionalUserProperties(File additionalUserProperties) {
+		this.additionalUserProperties = additionalUserProperties;
+	}
+	
 }


### PR DESCRIPTION
Hi,

I wrote some time ago that I have problem with and implementing something like : jmeter -q additionalProperties.property. And in the email I originally sent I really had a wrong path of the additionalProperties file. However after looking at the code I realized that ant has a problem with forwarding an argument containing 2 arguments of which one is file. 
So I added in my fork this property. 
For me in my jmeter tests is very handy having this additional property file and injecting them into jmeter test parameters, appart from the standard configuration
